### PR TITLE
Add ability to change close button widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -123,7 +123,7 @@ class _MySampleAppState extends State<MySampleApp> {
                             onPressed: onClose,
                             icon: const Icon(Icons.check_circle_outline),
                             iconAlignment: IconAlignment.end,
-                            label: const Text('Close'),
+                            label: const Text('Close😉'),
                           );
                         },
                       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -112,6 +112,23 @@ class _MySampleAppState extends State<MySampleApp> {
                       ),
                     ],
                   ),
+                  const SizedBox(height: 24),
+                  SectionWidget(
+                    title: 'Picker (Custom close button)',
+                    items: [
+                      PickerItemWidget(
+                        pickerType: DateTimePickerType.datetime,
+                        customCloseButtonBuilder: (context, isModal, onClose) {
+                          return TextButton.icon(
+                            onPressed: onClose,
+                            icon: const Icon(Icons.check_circle_outline),
+                            iconAlignment: IconAlignment.end,
+                            label: const Text('Close'),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),
@@ -195,9 +212,16 @@ class PickerItemWidget extends StatelessWidget {
   PickerItemWidget({
     super.key,
     required this.pickerType,
+    this.customCloseButtonBuilder,
   });
 
   final DateTimePickerType pickerType;
+
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 
   final ValueNotifier<DateTime> date = ValueNotifier(DateTime.now());
 
@@ -229,6 +253,7 @@ class PickerItemWidget extends StatelessWidget {
             // Specify if you want changes in the picker to take effect immediately.
             valueNotifier: date,
             controller: controller,
+            customCloseButtonBuilder: customCloseButtonBuilder,
             // onTopActionBuilder: (context) {
             //   return Padding(
             //     padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -127,6 +127,17 @@ class _MySampleAppState extends State<MySampleApp> {
                           );
                         },
                       ),
+                      PickerMultiSelectionItemWidget(
+                        pickerType: DateTimePickerType.datetime,
+                        customCloseButtonBuilder: (context, isModal, onClose) {
+                          return TextButton.icon(
+                            onPressed: onClose,
+                            icon: const Icon(Icons.check_circle_outline),
+                            iconAlignment: IconAlignment.end,
+                            label: const Text('Close😉'),
+                          );
+                        },
+                      ),
                     ],
                   ),
                 ],
@@ -341,9 +352,16 @@ class PickerMultiSelectionItemWidget extends StatelessWidget {
   PickerMultiSelectionItemWidget({
     super.key,
     required this.pickerType,
+    this.customCloseButtonBuilder,
   });
 
   final DateTimePickerType pickerType;
+
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 
   final ValueNotifier<DateTime> start = ValueNotifier(DateTime.now());
   final ValueNotifier<DateTime> end = ValueNotifier(
@@ -373,6 +391,7 @@ class PickerMultiSelectionItemWidget extends StatelessWidget {
               useAmpm: false,
               // topMargin: 0,
             ),
+            customCloseButtonBuilder: customCloseButtonBuilder,
             // headerWidget: Container(
             //   height: 60,
             //   margin: const EdgeInsets.all((8)),

--- a/lib/src/board_datetime_builder.dart
+++ b/lib/src/board_datetime_builder.dart
@@ -107,6 +107,7 @@ class BoardDateTimeBuilder<T extends BoardDateTimeCommonResult>
     this.resizeBottom = true,
     this.headerWidget,
     this.onTopActionBuilder,
+    this.customCloseButtonBuilder,
   });
 
   /// #### [DateTimeBuilder] Builder
@@ -149,6 +150,12 @@ class BoardDateTimeBuilder<T extends BoardDateTimeCommonResult>
 
   /// Specify a Widget to be displayed in the action button area externally
   final Widget Function(BuildContext context)? onTopActionBuilder;
+
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 
   @override
   State<BoardDateTimeBuilder> createState() => _BoardDateTimeBuilderState<T>();
@@ -251,6 +258,7 @@ class SingleBoardDateTimeContent<T extends BoardDateTimeCommonResult>
     super.onUpdateByClose,
     required super.headerWidget,
     required this.onTopActionBuilder,
+    super.customCloseButtonBuilder,
   });
 
   final void Function(DateTime)? onChange;
@@ -446,6 +454,7 @@ class _SingleBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       topMargin: widget.options.topMargin,
       onTopActionBuilder: widget.onTopActionBuilder,
       actionButtonTypes: widget.options.actionButtonTypes,
+      customCloseButtonBuilder: widget.customCloseButtonBuilder,
     );
   }
 }

--- a/lib/src/board_datetime_builder.dart
+++ b/lib/src/board_datetime_builder.dart
@@ -151,11 +151,7 @@ class BoardDateTimeBuilder<T extends BoardDateTimeCommonResult>
   /// Specify a Widget to be displayed in the action button area externally
   final Widget Function(BuildContext context)? onTopActionBuilder;
 
-  final Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder;
+  final CloseButtonBuilder? customCloseButtonBuilder;
 
   @override
   State<BoardDateTimeBuilder> createState() => _BoardDateTimeBuilderState<T>();

--- a/lib/src/board_datetime_multi_builder.dart
+++ b/lib/src/board_datetime_multi_builder.dart
@@ -30,6 +30,7 @@ class MultiBoardDateTimeContent<T extends BoardDateTimeCommonResult>
     this.onChange,
     this.onResult,
     required super.headerWidget,
+    super.customCloseButtonBuilder,
   });
 
   final DateTime startDate;

--- a/lib/src/board_datetime_multi_builder.dart
+++ b/lib/src/board_datetime_multi_builder.dart
@@ -373,6 +373,7 @@ class _MultiBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       onTopActionBuilder: widget.onTopActionBuilder,
       onReset: widget.options.useResetButton ? reset : null,
       useAmpm: widget.options.useAmpm,
+      customCloseButtonBuilder: widget.customCloseButtonBuilder,
     );
   }
 }

--- a/lib/src/board_datetime_widget.dart
+++ b/lib/src/board_datetime_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'board_datetime_builder.dart';
 import 'board_datetime_multi_builder.dart';
 import 'board_datetime_options.dart';
-import 'ui/parts/header.dart';
+import 'ui/board_datetime_contents_state.dart';
 import 'utils/board_datetime_result.dart';
 import 'utils/board_enum.dart';
 
@@ -48,7 +48,7 @@ Future<DateTime?> showBoardDateTimePickerForDateTime({
   bool enableDrag = true,
   bool? showDragHandle,
   bool useSafeArea = false,
-  final CloseButtonBuilder? customCloseButtonBuilder,
+  CloseButtonBuilder? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardDateTimeResult>(
     context: context,
@@ -118,7 +118,7 @@ Future<DateTime?> showBoardDateTimePickerForDate({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
-  final CloseButtonBuilder? customCloseButtonBuilder,
+  CloseButtonBuilder? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardDateResult>(
       context: context,
@@ -437,6 +437,7 @@ Future<BoardDateTimeMultiSelection?>
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  CloseButtonBuilder? customCloseButtonBuilder,
 }) async {
   final opt = options ?? const BoardDateTimeOptions();
 
@@ -479,6 +480,7 @@ Future<BoardDateTimeMultiSelection?>
           onChanged: onChanged,
           onResult: (val1, val2) => onResult?.call(val1 as T, val2 as T),
           onTopActionBuilder: onTopActionBuilder,
+          customCloseButtonBuilder: customCloseButtonBuilder,
         ),
       );
     },

--- a/lib/src/board_datetime_widget.dart
+++ b/lib/src/board_datetime_widget.dart
@@ -47,6 +47,11 @@ Future<DateTime?> showBoardDateTimePickerForDateTime({
   bool enableDrag = true,
   bool? showDragHandle,
   bool useSafeArea = false,
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardDateTimeResult>(
     context: context,
@@ -68,6 +73,7 @@ Future<DateTime?> showBoardDateTimePickerForDateTime({
     enableDrag: enableDrag,
     showDragHandle: showDragHandle,
     useSafeArea: useSafeArea,
+    customCloseButtonBuilder: customCloseButtonBuilder,
   );
 }
 
@@ -115,6 +121,11 @@ Future<DateTime?> showBoardDateTimePickerForDate({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardDateResult>(
       context: context,
@@ -138,7 +149,8 @@ Future<DateTime?> showBoardDateTimePickerForDate({
       enableDrag: enableDrag,
       showDragHandle: showDragHandle,
       useSafeArea: useSafeArea,
-      onTopActionBuilder: onTopActionBuilder);
+      onTopActionBuilder: onTopActionBuilder,
+      customCloseButtonBuilder: customCloseButtonBuilder);
 }
 
 /// Show a Modal Picker for Time bottom sheet.
@@ -185,30 +197,37 @@ Future<DateTime?> showBoardDateTimePickerForTime({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardTimeResult>(
-      context: context,
-      controller: controller,
-      valueNotifier: valueNotifier,
-      pickerType: DateTimePickerType.time,
-      onChanged: onChanged,
-      onResult: onResult,
-      initialDate: initialDate,
-      minimumDate: minimumDate,
-      maximumDate: maximumDate,
-      options: options,
-      headerWidget: headerWidget,
-      breakpoint: breakpoint,
-      radius: radius,
-      barrierColor: barrierColor,
-      routeSettings: routeSettings,
-      transitionAnimationController: transitionAnimationController,
-      useRootNavigator: useRootNavigator,
-      isDismissible: isDismissible,
-      enableDrag: enableDrag,
-      showDragHandle: showDragHandle,
-      useSafeArea: useSafeArea,
-      onTopActionBuilder: onTopActionBuilder);
+    context: context,
+    controller: controller,
+    valueNotifier: valueNotifier,
+    pickerType: DateTimePickerType.time,
+    onChanged: onChanged,
+    onResult: onResult,
+    initialDate: initialDate,
+    minimumDate: minimumDate,
+    maximumDate: maximumDate,
+    options: options,
+    headerWidget: headerWidget,
+    breakpoint: breakpoint,
+    radius: radius,
+    barrierColor: barrierColor,
+    routeSettings: routeSettings,
+    transitionAnimationController: transitionAnimationController,
+    useRootNavigator: useRootNavigator,
+    isDismissible: isDismissible,
+    enableDrag: enableDrag,
+    showDragHandle: showDragHandle,
+    useSafeArea: useSafeArea,
+    onTopActionBuilder: onTopActionBuilder,
+    customCloseButtonBuilder: customCloseButtonBuilder,
+  );
 }
 
 /// Show a BoardDateTimePicker modal bottom sheet.
@@ -259,6 +278,11 @@ Future<DateTime?> showBoardDateTimePicker<T extends BoardDateTimeCommonResult>({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder,
 }) async {
   final opt = options ?? const BoardDateTimeOptions();
 
@@ -300,6 +324,7 @@ Future<DateTime?> showBoardDateTimePicker<T extends BoardDateTimeCommonResult>({
           onChanged: onChanged,
           onResult: (val) => onResult?.call(val as T),
           onTopActionBuilder: onTopActionBuilder,
+          customCloseButtonBuilder: customCloseButtonBuilder,
         ),
       );
     },
@@ -320,6 +345,7 @@ class _SingleBoardDateTimeWidget extends StatefulWidget {
     this.onResult,
     required this.headerWidget,
     required this.onTopActionBuilder,
+    required this.customCloseButtonBuilder,
   });
 
   final BoardDateTimeController? controller;
@@ -334,6 +360,11 @@ class _SingleBoardDateTimeWidget extends StatefulWidget {
   final void Function(DateTime)? onChanged;
   final void Function(BoardDateTimeCommonResult)? onResult;
   final Widget Function(BuildContext context)? onTopActionBuilder;
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 
   @override
   State<_SingleBoardDateTimeWidget> createState() =>
@@ -376,6 +407,7 @@ class _SingleBoardDateTimeWidgetState
         widget.valueNotifier?.value = val;
       },
       onTopActionBuilder: widget.onTopActionBuilder,
+      customCloseButtonBuilder: widget.customCloseButtonBuilder,
     );
   }
 }
@@ -481,6 +513,7 @@ class _MultiBoardDateTimeWidget extends StatefulWidget {
     this.onChanged,
     this.onResult,
     this.headerWidget,
+    this.customCloseButtonBuilder,
   });
 
   final double breakpoint;
@@ -495,6 +528,11 @@ class _MultiBoardDateTimeWidget extends StatefulWidget {
   final void Function(BoardDateTimeMultiSelection)? onChanged;
   final void Function(BoardDateTimeCommonResult, BoardDateTimeCommonResult)?
       onResult;
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 
   @override
   State<_MultiBoardDateTimeWidget> createState() =>
@@ -540,6 +578,7 @@ class _MultiBoardDateTimeWidgetState extends State<_MultiBoardDateTimeWidget> {
           end: val2 ?? selection.end,
         );
       },
+      customCloseButtonBuilder: widget.customCloseButtonBuilder,
     );
   }
 }

--- a/lib/src/board_datetime_widget.dart
+++ b/lib/src/board_datetime_widget.dart
@@ -3,14 +3,9 @@ import 'package:flutter/material.dart';
 import 'board_datetime_builder.dart';
 import 'board_datetime_multi_builder.dart';
 import 'board_datetime_options.dart';
+import 'ui/parts/header.dart';
 import 'utils/board_datetime_result.dart';
 import 'utils/board_enum.dart';
-
-typedef CloseButtonBuilder = Widget Function(
-  BuildContext context,
-  bool isModal,
-  void Function() onClose,
-);
 
 /// Show a Modal Picker for DateTime bottom sheet.
 ///

--- a/lib/src/board_datetime_widget.dart
+++ b/lib/src/board_datetime_widget.dart
@@ -6,6 +6,12 @@ import 'board_datetime_options.dart';
 import 'utils/board_datetime_result.dart';
 import 'utils/board_enum.dart';
 
+typedef CloseButtonBuilder = Widget Function(
+  BuildContext context,
+  bool isModal,
+  void Function() onClose,
+);
+
 /// Show a Modal Picker for DateTime bottom sheet.
 ///
 /// The `context` argument is used to look up the [Navigator] and [Theme] for
@@ -47,11 +53,7 @@ Future<DateTime?> showBoardDateTimePickerForDateTime({
   bool enableDrag = true,
   bool? showDragHandle,
   bool useSafeArea = false,
-  final Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder,
+  final CloseButtonBuilder? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardDateTimeResult>(
     context: context,
@@ -121,11 +123,7 @@ Future<DateTime?> showBoardDateTimePickerForDate({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
-  final Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder,
+  final CloseButtonBuilder? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardDateResult>(
       context: context,
@@ -197,11 +195,7 @@ Future<DateTime?> showBoardDateTimePickerForTime({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
-  Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder,
+  CloseButtonBuilder? customCloseButtonBuilder,
 }) async {
   return await showBoardDateTimePicker<BoardTimeResult>(
     context: context,
@@ -278,11 +272,7 @@ Future<DateTime?> showBoardDateTimePicker<T extends BoardDateTimeCommonResult>({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
-  Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder,
+  CloseButtonBuilder? customCloseButtonBuilder,
 }) async {
   final opt = options ?? const BoardDateTimeOptions();
 
@@ -360,11 +350,7 @@ class _SingleBoardDateTimeWidget extends StatefulWidget {
   final void Function(DateTime)? onChanged;
   final void Function(BoardDateTimeCommonResult)? onResult;
   final Widget Function(BuildContext context)? onTopActionBuilder;
-  final Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder;
+  final CloseButtonBuilder? customCloseButtonBuilder;
 
   @override
   State<_SingleBoardDateTimeWidget> createState() =>
@@ -528,11 +514,7 @@ class _MultiBoardDateTimeWidget extends StatefulWidget {
   final void Function(BoardDateTimeMultiSelection)? onChanged;
   final void Function(BoardDateTimeCommonResult, BoardDateTimeCommonResult)?
       onResult;
-  final Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder;
+  final CloseButtonBuilder? customCloseButtonBuilder;
 
   @override
   State<_MultiBoardDateTimeWidget> createState() =>

--- a/lib/src/ui/board_datetime_contents_state.dart
+++ b/lib/src/ui/board_datetime_contents_state.dart
@@ -28,6 +28,7 @@ abstract class BoardDateTimeContent<T extends BoardDateTimeCommonResult>
     this.onKeyboadClose,
     this.onUpdateByClose,
     required this.headerWidget,
+    required this.customCloseButtonBuilder,
   });
 
   final double breakpoint;
@@ -59,6 +60,12 @@ abstract class BoardDateTimeContent<T extends BoardDateTimeCommonResult>
 
   /// To be displayed at the top of the picker
   final Widget? headerWidget;
+
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 }
 
 abstract class BoardDatetimeContentState<T extends BoardDateTimeCommonResult,

--- a/lib/src/ui/board_datetime_contents_state.dart
+++ b/lib/src/ui/board_datetime_contents_state.dart
@@ -1,7 +1,5 @@
 import 'dart:math';
 
-import 'package:board_datetime_picker/src/ui/parts/header.dart';
-import 'package:board_datetime_picker/src/utils/board_datetime_options_extension.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/date_symbol_data_local.dart';
 
@@ -10,6 +8,13 @@ import '../options/board_item_option.dart';
 import '../utils/board_datetime_result.dart';
 import '../utils/board_enum.dart';
 import '../utils/datetime_util.dart';
+import '../utils/board_datetime_options_extension.dart';
+
+typedef CloseButtonBuilder = Widget Function(
+  BuildContext context,
+  bool isModal,
+  void Function() onClose,
+);
 
 abstract class BoardDateTimeContent<T extends BoardDateTimeCommonResult>
     extends StatefulWidget {

--- a/lib/src/ui/parts/header.dart
+++ b/lib/src/ui/parts/header.dart
@@ -8,6 +8,12 @@ import 'package:flutter/material.dart';
 
 import 'buttons.dart';
 
+typedef CloseButtonBuilder = Widget Function(
+  BuildContext context,
+  bool isModal,
+  void Function() onClose,
+);
+
 class BoardDateTimeHeader extends StatefulWidget {
   const BoardDateTimeHeader({
     super.key,
@@ -112,12 +118,8 @@ class BoardDateTimeHeader extends StatefulWidget {
   /// List of buttons to select dates.
   final List<BoardDateButtonType> actionButtonTypes;
 
-  /// Custom Close Button
-  final Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder;
+  /// Custom Close Button Builder
+  final CloseButtonBuilder? customCloseButtonBuilder;
 
   @override
   State<BoardDateTimeHeader> createState() => BoardDateTimeHeaderState();
@@ -413,12 +415,8 @@ class BoardDateTimeNoneButtonHeader extends StatefulWidget {
   /// Picker FocusNode
   final FocusNode? pickerFocusNode;
 
-  // Custom Close Button
-  final Widget Function(
-    BuildContext context,
-    bool isModal,
-    void Function() onClose,
-  )? customCloseButtonBuilder;
+  // Custom Close Button Builder
+  final CloseButtonBuilder? customCloseButtonBuilder;
 
   @override
   State<BoardDateTimeNoneButtonHeader> createState() =>

--- a/lib/src/ui/parts/header.dart
+++ b/lib/src/ui/parts/header.dart
@@ -7,12 +7,7 @@ import 'package:board_datetime_picker/src/utils/datetime_util.dart';
 import 'package:flutter/material.dart';
 
 import 'buttons.dart';
-
-typedef CloseButtonBuilder = Widget Function(
-  BuildContext context,
-  bool isModal,
-  void Function() onClose,
-);
+import '../board_datetime_contents_state.dart';
 
 class BoardDateTimeHeader extends StatefulWidget {
   const BoardDateTimeHeader({
@@ -171,10 +166,35 @@ class BoardDateTimeHeaderState extends State<BoardDateTimeHeader> {
 
   double get height => widget.wide ? 64 : 52;
 
+  Widget _defaultCloseButtonBuilder(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  ) =>
+      isModal
+          ? IconButton(
+              onPressed: onClose,
+              icon: const Icon(Icons.check_circle_rounded),
+              color: widget.activeColor,
+            )
+          : Opacity(
+              opacity: 0.6,
+              child: IconButton(
+                onPressed: onClose,
+                icon: const Icon(Icons.close_rounded),
+                color: widget.textColor,
+              ),
+            );
+
   @override
   Widget build(BuildContext context) {
     final onReset = widget.onReset;
     final topActionWidget = widget.onTopActionBuilder?.call(context);
+
+    final closeButtonBuilder =
+        widget.customCloseButtonBuilder ?? _defaultCloseButtonBuilder;
+    final closeButton =
+        closeButtonBuilder(context, widget.modal, widget.onClose);
 
     final child = Container(
       height: height,
@@ -227,29 +247,8 @@ class BoardDateTimeHeaderState extends State<BoardDateTimeHeader> {
               ),
               onTap: () {},
             ),
-          if (widget.customCloseButtonBuilder != null) ...[
-            widget.customCloseButtonBuilder!(
-                context, widget.modal, widget.onClose),
-          ] else ...[
-            widget.modal
-                ? IconButton(
-                    onPressed: () {
-                      widget.onClose();
-                    },
-                    icon: const Icon(Icons.check_circle_rounded),
-                    color: widget.activeColor,
-                  )
-                : Opacity(
-                    opacity: 0.6,
-                    child: IconButton(
-                      onPressed: () {
-                        widget.onClose();
-                      },
-                      icon: const Icon(Icons.close_rounded),
-                      color: widget.textColor,
-                    ),
-                  ),
-          ]
+
+          closeButton,
         ],
       ),
     );

--- a/lib/src/ui/parts/header.dart
+++ b/lib/src/ui/parts/header.dart
@@ -35,6 +35,7 @@ class BoardDateTimeHeader extends StatefulWidget {
     required this.topMargin,
     required this.onTopActionBuilder,
     required this.actionButtonTypes,
+    required this.customCloseButtonBuilder,
   });
 
   /// Wide mode display flag
@@ -110,6 +111,13 @@ class BoardDateTimeHeader extends StatefulWidget {
 
   /// List of buttons to select dates.
   final List<BoardDateButtonType> actionButtonTypes;
+
+  /// Custom Close Button
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 
   @override
   State<BoardDateTimeHeader> createState() => BoardDateTimeHeaderState();
@@ -197,24 +205,29 @@ class BoardDateTimeHeaderState extends State<BoardDateTimeHeader> {
           //     ),
           //   ),
           // ),
-          widget.modal
-              ? IconButton(
-                  onPressed: () {
-                    widget.onClose();
-                  },
-                  icon: const Icon(Icons.check_circle_rounded),
-                  color: widget.activeColor,
-                )
-              : Opacity(
-                  opacity: 0.6,
-                  child: IconButton(
+          if (widget.customCloseButtonBuilder != null) ...[
+            widget.customCloseButtonBuilder!(
+                context, widget.modal, widget.onClose),
+          ] else ...[
+            widget.modal
+                ? IconButton(
                     onPressed: () {
                       widget.onClose();
                     },
-                    icon: const Icon(Icons.close_rounded),
-                    color: widget.textColor,
+                    icon: const Icon(Icons.check_circle_rounded),
+                    color: widget.activeColor,
+                  )
+                : Opacity(
+                    opacity: 0.6,
+                    child: IconButton(
+                      onPressed: () {
+                        widget.onClose();
+                      },
+                      icon: const Icon(Icons.close_rounded),
+                      color: widget.textColor,
+                    ),
                   ),
-                ),
+          ]
         ],
       ),
     );
@@ -365,6 +378,7 @@ class BoardDateTimeNoneButtonHeader extends StatefulWidget {
     required this.onClose,
     required this.modal,
     required this.pickerFocusNode,
+    this.customCloseButtonBuilder,
   });
 
   final BoardDateTimeOptions options;
@@ -398,6 +412,13 @@ class BoardDateTimeNoneButtonHeader extends StatefulWidget {
 
   /// Picker FocusNode
   final FocusNode? pickerFocusNode;
+
+  // Custom Close Button
+  final Widget Function(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  )? customCloseButtonBuilder;
 
   @override
   State<BoardDateTimeNoneButtonHeader> createState() =>
@@ -490,21 +511,26 @@ class _BoardDateTimeNoneButtonHeaderState
     //   );
     // }
 
-    Widget child = widget.modal
-        ? CustomIconButton(
-            icon: Icons.check_circle_rounded,
-            bgColor: widget.options.getActiveColor(context),
-            fgColor: widget.options.getActiveTextColor(context),
-            onTap: widget.onClose,
-            buttonSize: buttonSize,
-          )
-        : CustomIconButton(
-            icon: Icons.close_rounded,
-            bgColor: widget.options.getForegroundColor(context),
-            fgColor: widget.options.getTextColor(context)?.withOpacity(0.8),
-            onTap: widget.onClose,
-            buttonSize: buttonSize,
-          );
+    Widget child = widget.customCloseButtonBuilder?.call(
+          context,
+          widget.modal,
+          widget.onClose,
+        ) ??
+        (widget.modal
+            ? CustomIconButton(
+                icon: Icons.check_circle_rounded,
+                bgColor: widget.options.getActiveColor(context),
+                fgColor: widget.options.getActiveTextColor(context),
+                onTap: widget.onClose,
+                buttonSize: buttonSize,
+              )
+            : CustomIconButton(
+                icon: Icons.close_rounded,
+                bgColor: widget.options.getForegroundColor(context),
+                fgColor: widget.options.getTextColor(context)?.withOpacity(0.8),
+                onTap: widget.onClose,
+                buttonSize: buttonSize,
+              ));
 
     return [
       // if (closeKeyboard != null) ...[

--- a/lib/src/ui/parts/header_multi.dart
+++ b/lib/src/ui/parts/header_multi.dart
@@ -1,11 +1,12 @@
 import 'dart:math';
 
-import 'package:board_datetime_picker/src/utils/datetime_util.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../board_datetime_contents_state.dart';
 import '../../board_datetime_options.dart';
 import '../../utils/board_enum.dart';
+import '../../utils/datetime_util.dart';
 
 class BoardDateTimeMultiHeader extends StatefulWidget {
   const BoardDateTimeMultiHeader({
@@ -37,6 +38,7 @@ class BoardDateTimeMultiHeader extends StatefulWidget {
     required this.onTopActionBuilder,
     required this.onReset,
     required this.useAmpm,
+    required this.customCloseButtonBuilder,
   });
 
   /// Wide mode display flag
@@ -122,6 +124,9 @@ class BoardDateTimeMultiHeader extends StatefulWidget {
   /// Flag whether AM/PM mode is used
   final bool useAmpm;
 
+  /// Custom Close Button Builder
+  final CloseButtonBuilder? customCloseButtonBuilder;
+
   @override
   State<BoardDateTimeMultiHeader> createState() =>
       _BoardDateTimeMultiHeaderState();
@@ -170,29 +175,38 @@ class _BoardDateTimeMultiHeaderState extends State<BoardDateTimeMultiHeader>
     }
   }
 
+  Widget _defaultCloseButtonBuilder(
+    BuildContext context,
+    bool isModal,
+    void Function() onClose,
+  ) =>
+      Container(
+        width: 40,
+        alignment: Alignment.center,
+        child: isModal
+            ? IconButton(
+                onPressed: onClose,
+                icon: const Icon(Icons.check_circle_rounded),
+                color: widget.activeColor,
+              )
+            : Opacity(
+                opacity: 0.6,
+                child: IconButton(
+                  onPressed: onClose,
+                  icon: const Icon(Icons.close_rounded),
+                  color: widget.textColor,
+                ),
+              ),
+      );
+
   @override
   Widget build(BuildContext context) {
     final onReset = widget.onReset;
     final topActionWidget = widget.onTopActionBuilder?.call(context);
 
-    final rightIcon = widget.modal
-        ? IconButton(
-            onPressed: () {
-              widget.onClose();
-            },
-            icon: const Icon(Icons.check_circle_rounded),
-            color: widget.activeColor,
-          )
-        : Opacity(
-            opacity: 0.6,
-            child: IconButton(
-              onPressed: () {
-                widget.onClose();
-              },
-              icon: const Icon(Icons.close_rounded),
-              color: widget.textColor,
-            ),
-          );
+    final closeButtonBuilder =
+        widget.customCloseButtonBuilder ?? _defaultCloseButtonBuilder;
+    final rightIcon = closeButtonBuilder(context, widget.modal, widget.onClose);
 
     final child = Container(
       height: widget.wide ? 64 : 52,
@@ -279,11 +293,7 @@ class _BoardDateTimeMultiHeaderState extends State<BoardDateTimeMultiHeader>
               onTap: () {},
             ),
           GestureDetector(
-            child: Container(
-              width: 40,
-              alignment: Alignment.center,
-              child: rightIcon,
-            ),
+            child: rightIcon,
             onTap: () {},
           ),
         ],


### PR DESCRIPTION
Hello,

As users of our mobile app might not be able to recognize that the date is fixed by the check mark icon, I wanted to be able to display the text.

However, in order to make it widely and flexibly usable (regardless of our use case), we have made it possible to give the Builder that creates the Widget.

If you have any questions about how to refine the code, please don't hesitate to ask.

Finally, thank you for developing such a good plugin!

-----

| SINGLE | MULTI |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5d55d1ff-e9ee-4eb9-a7b8-8acff87a67ce" width="200" /> | <img src="https://github.com/user-attachments/assets/133ee1f4-8e04-4397-8a06-e1fb84496fa9" width="200" /> |

