### PR TITLE
feat -> confirmButton

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -112,6 +112,50 @@ class _MySampleAppState extends State<MySampleApp> {
                       ),
                     ],
                   ),
+                  const SizedBox(height: 24),
+                  SectionWidget(
+                    title: 'Custom Confirmation Button',
+                    items: [
+                      PickerItemWidget(
+                        pickerType: DateTimePickerType.date,
+                        confirmButtonOnly: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          margin: const EdgeInsets.only(right: 12),
+                          decoration: BoxDecoration(
+                              color: Colors.deepPurpleAccent,
+                              borderRadius: BorderRadius.circular(8)),
+                          child: const Text(
+                            "submit-Only",
+                            style: TextStyle(
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                      ),
+                      PickerItemWidget(
+                        pickerType: DateTimePickerType.time,
+                        confirmButtonOption: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          margin: const EdgeInsets.only(right: 12),
+                          decoration: BoxDecoration(
+                              color: Colors.green,
+                              borderRadius: BorderRadius.circular(8)),
+                          child: const Text(
+                            "submit-Option",
+                            style: TextStyle(
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),
@@ -195,9 +239,14 @@ class PickerItemWidget extends StatelessWidget {
   PickerItemWidget({
     super.key,
     required this.pickerType,
+    this.confirmButtonOnly,
+    this.confirmButtonOption,
   });
 
   final DateTimePickerType pickerType;
+
+  final Widget? confirmButtonOnly;
+  final Widget? confirmButtonOption;
 
   final ValueNotifier<DateTime> date = ValueNotifier(DateTime.now());
 
@@ -211,12 +260,14 @@ class PickerItemWidget extends StatelessWidget {
           final result = await showBoardDateTimePicker(
             context: context,
             pickerType: pickerType,
+            confirmButton: confirmButtonOnly,
             // initialDate: DateTime.now(),
             // minimumDate: DateTime.now().add(const Duration(days: 1)),
             options: BoardDateTimeOptions(
               languages: const BoardPickerLanguages.en(),
               startDayOfWeek: DateTime.sunday,
               pickerFormat: PickerFormat.ymd,
+              confirmButton: confirmButtonOption,
               // boardTitle: 'Board Picker',
               // pickerSubTitles: BoardDateTimeItemTitles(year: 'year'),
               withSecond: DateTimePickerType.time == pickerType,

--- a/lib/src/board_datetime_builder.dart
+++ b/lib/src/board_datetime_builder.dart
@@ -107,6 +107,7 @@ class BoardDateTimeBuilder<T extends BoardDateTimeCommonResult>
     this.resizeBottom = true,
     this.headerWidget,
     this.onTopActionBuilder,
+    this.confirmButton,
   });
 
   /// #### [DateTimeBuilder] Builder
@@ -149,6 +150,9 @@ class BoardDateTimeBuilder<T extends BoardDateTimeCommonResult>
 
   /// Specify a Widget to be displayed in the action button area externally
   final Widget Function(BuildContext context)? onTopActionBuilder;
+
+  /// you can see it to [BoardDateTimeHeader.confirmButton]
+  final Widget? confirmButton;
 
   @override
   State<BoardDateTimeBuilder> createState() => _BoardDateTimeBuilderState<T>();
@@ -200,6 +204,7 @@ class _BoardDateTimeBuilderState<T extends BoardDateTimeCommonResult>
         keyboardHeightNotifier: keyboardHeightNotifier,
         headerWidget: widget.headerWidget,
         onTopActionBuilder: widget.onTopActionBuilder,
+        confirmButton: widget.confirmButton,
       );
     }
 
@@ -251,6 +256,7 @@ class SingleBoardDateTimeContent<T extends BoardDateTimeCommonResult>
     super.onUpdateByClose,
     required super.headerWidget,
     required super.onTopActionBuilder,
+    required super.confirmButton,
   });
 
   final void Function(DateTime)? onChange;
@@ -460,6 +466,7 @@ class _SingleBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       onTopActionBuilder: widget.onTopActionBuilder,
       actionButtonTypes: widget.options.actionButtonTypes,
       onReset: widget.options.useResetButton ? reset : null,
+      confirmButton: widget.confirmButton ?? widget.options.confirmButton,
     );
   }
 }

--- a/lib/src/board_datetime_input_field.dart
+++ b/lib/src/board_datetime_input_field.dart
@@ -172,6 +172,7 @@ class BoardDateTimeInputField<T extends BoardDateTimeCommonResult>
     this.readOnly = false,
     this.enabled,
     this.onTopActionBuilder,
+    this.confirmButton,
   });
 
   /// #### Date of initial selection state.
@@ -223,6 +224,9 @@ class BoardDateTimeInputField<T extends BoardDateTimeCommonResult>
 
   /// Specify a Widget to be displayed in the action button area externally
   final Widget Function(BuildContext context)? onTopActionBuilder;
+
+  /// you can see it to [BoardDateTimeHeader.confirmButton]
+  final Widget? confirmButton;
 
   final double breakpoint;
 
@@ -1061,6 +1065,7 @@ class _BoardDateTimeInputFieldState<T extends BoardDateTimeCommonResult>
           onKeyboadClose: onClosePicker,
           headerWidget: null,
           onTopActionBuilder: widget.onTopActionBuilder,
+          confirmButton: widget.confirmButton,
         ),
       ),
     );

--- a/lib/src/board_datetime_multi_builder.dart
+++ b/lib/src/board_datetime_multi_builder.dart
@@ -43,6 +43,7 @@ class MultiBoardDateTimeContent<T extends BoardDateTimeCommonResult>
     this.onResult,
     required super.headerWidget,
     required super.onTopActionBuilder,
+    required super.confirmButton,
   });
 
   final BoardMultiDateTimeController? controller;
@@ -370,6 +371,7 @@ class _MultiBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       onChangeDateType: onChangeDateType,
       topMargin: widget.options.topMargin,
       onTopActionBuilder: widget.onTopActionBuilder,
+      confirmButton: widget.confirmButton ?? widget.options.confirmButton,
       onReset: widget.options.useResetButton ? reset : null,
       useAmpm: widget.options.useAmpm,
     );

--- a/lib/src/board_datetime_options.dart
+++ b/lib/src/board_datetime_options.dart
@@ -32,6 +32,7 @@ class BoardDateTimeOptions {
     this.calendarSelectionBuilder,
     this.useResetButton = false,
     this.useAmpm = false,
+    this.confirmButton,
   });
 
   /// #### Picker Background Color
@@ -177,6 +178,9 @@ class BoardDateTimeOptions {
   /// Set if the time is to be displayed as AM/PM.
   /// This value is valid only for `DateTimePickerType.time`
   final bool useAmpm;
+
+  /// you can see it to [BoardDateTimeHeader.confirmButton]
+  final Widget? confirmButton;
 }
 
 enum BoardDateButtonType { yesterday, today, tomorrow }

--- a/lib/src/board_datetime_widget.dart
+++ b/lib/src/board_datetime_widget.dart
@@ -115,6 +115,7 @@ Future<DateTime?> showBoardDateTimePickerForDate({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  Widget? confirmButton,
 }) async {
   return await showBoardDateTimePicker<BoardDateResult>(
       context: context,
@@ -138,7 +139,8 @@ Future<DateTime?> showBoardDateTimePickerForDate({
       enableDrag: enableDrag,
       showDragHandle: showDragHandle,
       useSafeArea: useSafeArea,
-      onTopActionBuilder: onTopActionBuilder);
+      onTopActionBuilder: onTopActionBuilder,
+      confirmButton: confirmButton);
 }
 
 /// Show a Modal Picker for Time bottom sheet.
@@ -185,6 +187,7 @@ Future<DateTime?> showBoardDateTimePickerForTime({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  final Widget? confirmButton,
 }) async {
   return await showBoardDateTimePicker<BoardTimeResult>(
       context: context,
@@ -208,7 +211,8 @@ Future<DateTime?> showBoardDateTimePickerForTime({
       enableDrag: enableDrag,
       showDragHandle: showDragHandle,
       useSafeArea: useSafeArea,
-      onTopActionBuilder: onTopActionBuilder);
+      onTopActionBuilder: onTopActionBuilder,
+      confirmButton: confirmButton);
 }
 
 /// Show a BoardDateTimePicker modal bottom sheet.
@@ -259,6 +263,7 @@ Future<DateTime?> showBoardDateTimePicker<T extends BoardDateTimeCommonResult>({
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  Widget? confirmButton,
 }) async {
   final opt = options ?? const BoardDateTimeOptions();
 
@@ -300,6 +305,7 @@ Future<DateTime?> showBoardDateTimePicker<T extends BoardDateTimeCommonResult>({
           onChanged: onChanged,
           onResult: (val) => onResult?.call(val as T),
           onTopActionBuilder: onTopActionBuilder,
+          confirmButton: confirmButton,
         ),
       );
     },
@@ -320,6 +326,7 @@ class _SingleBoardDateTimeWidget extends StatefulWidget {
     this.onResult,
     required this.headerWidget,
     required this.onTopActionBuilder,
+    required this.confirmButton,
   });
 
   final BoardDateTimeController? controller;
@@ -334,6 +341,7 @@ class _SingleBoardDateTimeWidget extends StatefulWidget {
   final void Function(DateTime)? onChanged;
   final void Function(BoardDateTimeCommonResult)? onResult;
   final Widget Function(BuildContext context)? onTopActionBuilder;
+  final Widget? confirmButton;
 
   @override
   State<_SingleBoardDateTimeWidget> createState() =>
@@ -376,6 +384,7 @@ class _SingleBoardDateTimeWidgetState
         widget.valueNotifier?.value = val;
       },
       onTopActionBuilder: widget.onTopActionBuilder,
+      confirmButton: widget.confirmButton,
     );
   }
 }
@@ -424,6 +433,7 @@ Future<BoardDateTimeMultiSelection?>
   bool? showDragHandle,
   bool useSafeArea = false,
   Widget Function(BuildContext context)? onTopActionBuilder,
+  Widget? confirmButton,
 }) async {
   final opt = options ?? const BoardDateTimeOptions();
 
@@ -466,6 +476,7 @@ Future<BoardDateTimeMultiSelection?>
           onChanged: onChanged,
           onResult: (val1, val2) => onResult?.call(val1 as T, val2 as T),
           onTopActionBuilder: onTopActionBuilder,
+          confirmButton: confirmButton,
         ),
       );
     },
@@ -487,6 +498,7 @@ class _MultiBoardDateTimeWidget extends StatefulWidget {
     this.onResult,
     this.headerWidget,
     this.onTopActionBuilder,
+    this.confirmButton,
   });
 
   final BoardMultiDateTimeController? controller;
@@ -503,6 +515,7 @@ class _MultiBoardDateTimeWidget extends StatefulWidget {
   final void Function(BoardDateTimeCommonResult, BoardDateTimeCommonResult)?
       onResult;
   final Widget Function(BuildContext context)? onTopActionBuilder;
+  final Widget? confirmButton;
 
   @override
   State<_MultiBoardDateTimeWidget> createState() =>
@@ -569,6 +582,7 @@ class _MultiBoardDateTimeWidgetState extends State<_MultiBoardDateTimeWidget> {
         );
       },
       onTopActionBuilder: widget.onTopActionBuilder,
+      confirmButton: widget.confirmButton,
     );
   }
 }

--- a/lib/src/ui/board_datetime_contents_state.dart
+++ b/lib/src/ui/board_datetime_contents_state.dart
@@ -29,6 +29,7 @@ abstract class BoardDateTimeContent<T extends BoardDateTimeCommonResult>
     this.onUpdateByClose,
     required this.headerWidget,
     required this.onTopActionBuilder,
+    required this.confirmButton,
   });
 
   final double breakpoint;
@@ -63,6 +64,9 @@ abstract class BoardDateTimeContent<T extends BoardDateTimeCommonResult>
 
   /// Specify a Widget to be displayed in the action button area externally
   final Widget Function(BuildContext context)? onTopActionBuilder;
+
+  /// you can see it to [BoardDateTimeHeader.confirmButton]
+  final Widget? confirmButton;
 }
 
 abstract class BoardDatetimeContentState<T extends BoardDateTimeCommonResult,

--- a/lib/src/ui/parts/header.dart
+++ b/lib/src/ui/parts/header.dart
@@ -36,6 +36,7 @@ class BoardDateTimeHeader extends StatefulWidget {
     required this.onTopActionBuilder,
     required this.actionButtonTypes,
     required this.onReset,
+    required this.confirmButton,
   });
 
   /// Wide mode display flag
@@ -114,6 +115,15 @@ class BoardDateTimeHeader extends StatefulWidget {
 
   /// reset button callback (if use reset)
   final void Function()? onReset;
+
+  /// Confirm button , Render result:
+  /// ```dart
+  /// GestureDetector(
+  ///   onTap: ()=> close()
+  ///   child: confirmButton
+  /// )
+  /// ```
+  final Widget? confirmButton;
 
   @override
   State<BoardDateTimeHeader> createState() => BoardDateTimeHeaderState();
@@ -217,24 +227,32 @@ class BoardDateTimeHeaderState extends State<BoardDateTimeHeader> {
               ),
               onTap: () {},
             ),
-          widget.modal
-              ? IconButton(
-                  onPressed: () {
-                    widget.onClose();
-                  },
-                  icon: const Icon(Icons.check_circle_rounded),
-                  color: widget.activeColor,
-                )
-              : Opacity(
-                  opacity: 0.6,
-                  child: IconButton(
+          if (widget.confirmButton != null)
+            GestureDetector(
+              onTap: () {
+                widget.onClose();
+              },
+              child: widget.confirmButton!,
+            ),
+          if (widget.confirmButton == null)
+            widget.modal
+                ? IconButton(
                     onPressed: () {
                       widget.onClose();
                     },
-                    icon: const Icon(Icons.close_rounded),
-                    color: widget.textColor,
+                    icon: const Icon(Icons.check_circle_rounded),
+                    color: widget.activeColor,
+                  )
+                : Opacity(
+                    opacity: 0.6,
+                    child: IconButton(
+                      onPressed: () {
+                        widget.onClose();
+                      },
+                      icon: const Icon(Icons.close_rounded),
+                      color: widget.textColor,
+                    ),
                   ),
-                ),
         ],
       ),
     );

--- a/lib/src/ui/parts/header_multi.dart
+++ b/lib/src/ui/parts/header_multi.dart
@@ -35,6 +35,7 @@ class BoardDateTimeMultiHeader extends StatefulWidget {
     required this.pickerFormat,
     required this.topMargin,
     required this.onTopActionBuilder,
+    required this.confirmButton,
     required this.onReset,
     required this.useAmpm,
   });
@@ -115,6 +116,9 @@ class BoardDateTimeMultiHeader extends StatefulWidget {
 
   /// Specify a Widget to be displayed in the action button area externally
   final Widget Function(BuildContext context)? onTopActionBuilder;
+
+  /// you can see it to [BoardDateTimeHeader.confirmButton]
+  final Widget? confirmButton;
 
   /// reset button callback (if use reset)
   final void Function()? onReset;
@@ -278,14 +282,22 @@ class _BoardDateTimeMultiHeaderState extends State<BoardDateTimeMultiHeader>
               ),
               onTap: () {},
             ),
-          GestureDetector(
-            child: Container(
-              width: 40,
-              alignment: Alignment.center,
-              child: rightIcon,
+          if (widget.confirmButton != null)
+            GestureDetector(
+              onTap: () {
+                widget.onClose();
+              },
+              child: widget.confirmButton,
             ),
-            onTap: () {},
-          ),
+          if (widget.confirmButton == null)
+            GestureDetector(
+              child: Container(
+                width: 40,
+                alignment: Alignment.center,
+                child: rightIcon,
+              ),
+              onTap: () {},
+            ),
         ],
       ),
     );


### PR DESCRIPTION
We believe the "check" button can easily cause confusion, as it is often interpreted by users as an action to "check" something rather than "submit." This concern has been raised by several users. Therefore, I added a customizable confirmation button widget, allowing developers to adjust it. Since options are often used as global configurations, I also implemented the ability to use it within the showBoardDateTimePicker function. The function's properties take priority, followed by the configuration from the options.