### PR TITLE
fix: Performance issues caused by a significant gap between minimumDate and maximumDate

### DIFF
--- a/lib/src/options/board_item_option.dart
+++ b/lib/src/options/board_item_option.dart
@@ -188,7 +188,7 @@ class BoardPickerItemOption {
   /// Max Length for TextField
   int get maxLength {
     if (type == DateType.year) {
-      return 4;
+      return max(minimumDate.year.toString().length, maximumDate.year.toString().length);
     } else if (type == DateType.month) {
       if (monthFormat == PickerMonthFormat.number) {
         return 2;

--- a/lib/src/ui/parts/item.dart
+++ b/lib/src/ui/parts/item.dart
@@ -342,10 +342,11 @@ class ItemWidgetState extends State<ItemWidget>
                               perspective: 0.01,
                               clipBehavior: Clip.antiAliasWithSaveLayer,
                               onSelectedItemChanged: onChange,
-                              childDelegate: ListWheelChildListDelegate(
-                                children: [
-                                  for (final i in map.keys) _item(i),
-                                ],
+                              childDelegate: ListWheelChildBuilderDelegate(
+                                builder: (BuildContext context, int index) {
+                                  return _item(index);
+                                },
+                                childCount: map.keys.length,
                               ),
                             ),
                           ),
@@ -726,10 +727,11 @@ class AmpmItemWidgetState extends State<AmpmItemWidget> {
                               perspective: 0.01,
                               clipBehavior: Clip.antiAliasWithSaveLayer,
                               onSelectedItemChanged: onChange,
-                              childDelegate: ListWheelChildListDelegate(
-                                children: [
-                                  for (final i in map.keys) _item(i),
-                                ],
+                              childDelegate: ListWheelChildBuilderDelegate(
+                                builder: (BuildContext context, int index) {
+                                  return _item(index);
+                                },
+                                childCount: map.keys.length,
                               ),
                             ),
                           ),


### PR DESCRIPTION
Fixed the issue where items lag when minimumDate and maximumDate are too large, For example minimumDate specifies DateTime(1, 12, 31, 23, 59, 59), and maximumDate specifies DateTime(9999, 12, 31, 23, 59, 59). Rolling years will be very laggy.