### PR TITLE
Fixed a stale foreground color after the theme changed and resource leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.8.6
+
+* Fixed the correction flash animation using a stale foreground color after the theme changed.
+* Fixed memory leaks by disposing focus nodes, timers, animation controllers and notifiers that were left undisposed (`BoardDateTimeBuilder`, `BoardDateTimeInputField`, `BoardMultiDateTimeController`, picker item widgets).
+* Fixed an issue where focus listeners on picker item options were not removed when the picker type changed, which could cause stale callbacks to fire.
+* Replaced deprecated `SizeTransition.axisAlignment` with `alignment`.
+
 ## 2.8.5
 
 * Fixed the issue where items lag when minimumDate and maximumDate are too large.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In order to add board_datetime_picker package to your project add this line to y
 
 ```yaml
 dependencies:
-    board_datetime_picker: 2.8.5
+    board_datetime_picker: 2.8.6
 ```
 
 ## Usage

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,8 +1,13 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }
 
 android {
@@ -11,12 +16,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=true
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "9.2.1" apply false
 }
 
 include ":app"

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,16 @@
-import UIKit
 import Flutter
+import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -43,9 +68,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,21 +13,15 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Board DateTime Picker Example',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.blue,
-          brightness: Brightness.light,
-        ),
+        brightness: Brightness.light,
         scaffoldBackgroundColor: const Color.fromARGB(255, 235, 235, 241),
-        useMaterial3: true,
+        useMaterial3: false,
         primaryColor: Colors.blue,
       ),
       darkTheme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.blue,
-          brightness: Brightness.dark,
-        ),
+        brightness: Brightness.dark,
         scaffoldBackgroundColor: const Color.fromARGB(255, 18, 18, 18),
-        useMaterial3: true,
+        useMaterial3: false,
         primaryColor: Colors.blue,
       ),
       themeMode: ThemeMode.system,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,11 +13,20 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Board DateTime Picker Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
-        scaffoldBackgroundColor: const Color.fromARGB(255, 235, 235, 241),
-        useMaterial3: false,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        useMaterial3: true,
       ),
-      // home: const Home(),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.blue,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      ),
+      themeMode: ThemeMode.system,
       home: const MySampleApp(),
     );
   }
@@ -50,7 +59,7 @@ class _MySampleAppState extends State<MySampleApp> {
         appBar: AppBar(
           title: const Text('Board DateTime Picker Example'),
         ),
-        backgroundColor: const Color.fromARGB(255, 245, 245, 250),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         body: SingleChildScrollView(
           controller: scrollController,
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 40),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,14 +17,18 @@ class MyApp extends StatelessWidget {
           seedColor: Colors.blue,
           brightness: Brightness.light,
         ),
+        scaffoldBackgroundColor: const Color.fromARGB(255, 235, 235, 241),
         useMaterial3: true,
+        primaryColor: Colors.blue,
       ),
       darkTheme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: Colors.blue,
           brightness: Brightness.dark,
         ),
+        scaffoldBackgroundColor: const Color.fromARGB(255, 18, 18, 18),
         useMaterial3: true,
+        primaryColor: Colors.blue,
       ),
       themeMode: ThemeMode.system,
       home: const MySampleApp(),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -34,9 +34,9 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
-  intl: ^0.19.0
-  provider: ^6.1.2
+  cupertino_icons: ^1.0.9
+  intl: ^0.20.2
+  provider: ^6.1.5
 
   board_datetime_picker:
     path: ../
@@ -50,7 +50,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/board_datetime_picker.dart
+++ b/lib/board_datetime_picker.dart
@@ -1,5 +1,3 @@
-library board_datetime_picker;
-
 import 'package:intl/intl.dart';
 
 export 'src/board_datetime_builder.dart'

--- a/lib/src/board_datetime_builder.dart
+++ b/lib/src/board_datetime_builder.dart
@@ -186,6 +186,12 @@ class _BoardDateTimeBuilderState<T extends BoardDateTimeCommonResult>
   }
 
   @override
+  void dispose() {
+    keyboardHeightNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     keyboardHeightNotifier.value = MediaQuery.of(context).viewInsets.bottom;
 
@@ -254,7 +260,7 @@ class SingleBoardDateTimeContent<T extends BoardDateTimeCommonResult>
     super.keyboardHeightNotifier,
     super.onCreatedDateState,
     super.pickerFocusNode,
-    super.onKeyboadClose,
+    super.onKeyboardClose,
     super.onUpdateByClose,
     required super.headerWidget,
     required super.onTopActionBuilder,
@@ -380,7 +386,7 @@ class _SingleBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       headerBuilder: (ctx) => _header,
       onChangeByCalendar: changeDate,
       onChangeByPicker: onChangeByPicker,
-      onKeyboadClose: closeKeyboard,
+      onKeyboardClose: closeKeyboard,
       keyboardHeightRatio: () => keyboardHeightRatio,
     );
 
@@ -389,7 +395,7 @@ class _SingleBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       child: SizeTransition(
         sizeFactor: animation,
         axis: Axis.vertical,
-        axisAlignment: -1.0,
+        alignment: const Alignment(-1.0, -1.0),
         // child: isWide ? _widebuilder() : _standardBuilder(),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -447,7 +453,7 @@ class _SingleBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
         keyboardHeightRatio: keyboardHeightRatio,
         calendarAnimation: calendarAnimation,
         onCalendar: onCalendar,
-        onKeyboadClose: closeKeyboard,
+        onKeyboardClose: closeKeyboard,
         onClose: close,
         modal: widget.modal,
         pickerFocusNode: widget.pickerFocusNode,
@@ -465,7 +471,7 @@ class _SingleBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       onCalendar: onCalendar,
       onChangeDate: changeDate,
       onChangTime: changeTime,
-      onKeyboadClose: closeKeyboard,
+      onKeyboardClose: closeKeyboard,
       onClose: close,
       backgroundColor: widget.options.getBackgroundColor(context),
       foregroundColor: widget.options.getForegroundColor(context),

--- a/lib/src/board_datetime_input_field.dart
+++ b/lib/src/board_datetime_input_field.dart
@@ -553,6 +553,10 @@ class _BoardDateTimeInputFieldState<T extends BoardDateTimeCommonResult>
     closePicker(disposed: true);
     focusNodeDebounce?.cancel();
     focusNode.removeListener(_focusListener);
+    // Only dispose the FocusNode if it was created internally;
+    // externally provided nodes are owned by the caller.
+    if (widget.focusNode == null) focusNode.dispose();
+    pickerFocusNode.dispose();
     pickerDateState?.removeListener(pickerListener);
     textController.dispose();
     overlayAnimController.dispose();
@@ -1058,7 +1062,7 @@ class _BoardDateTimeInputFieldState<T extends BoardDateTimeCommonResult>
               pickerDateState!.addListener(pickerListener);
             },
             onCloseModal: onClosePicker,
-            onKeyboadClose: onClosePicker,
+            onKeyboardClose: onClosePicker,
             headerWidget: null,
             onTopActionBuilder: widget.onTopActionBuilder,
             embeddedOptions: const EmbeddedOptions(),

--- a/lib/src/board_datetime_multi_builder.dart
+++ b/lib/src/board_datetime_multi_builder.dart
@@ -38,7 +38,7 @@ class MultiBoardDateTimeContent<T extends BoardDateTimeCommonResult>
     super.keyboardHeightNotifier,
     super.onCreatedDateState,
     super.pickerFocusNode,
-    super.onKeyboadClose,
+    super.onKeyboardClose,
     super.onUpdateByClose,
     this.onChange,
     this.onResult,
@@ -190,6 +190,7 @@ class _MultiBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
   void dispose() {
     startDate.removeListener(notify);
     endDate.removeListener(notify);
+    currentDateType.dispose();
     super.dispose();
   }
 
@@ -319,7 +320,7 @@ class _MultiBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       headerBuilder: (ctx) => _header,
       onChangeByCalendar: changeDate,
       onChangeByPicker: onChangeByPicker,
-      onKeyboadClose: closeKeyboard,
+      onKeyboardClose: closeKeyboard,
       keyboardHeightRatio: () => keyboardHeightRatio,
       startDate: startDate,
       endDate: endDate,
@@ -336,7 +337,7 @@ class _MultiBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       child: SizeTransition(
         sizeFactor: animation,
         axis: Axis.vertical,
-        axisAlignment: -1.0,
+        alignment: const Alignment(-1.0, -1.0),
         // child: isWide ? _widebuilder() : _standardBuilder(),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -417,7 +418,7 @@ class _MultiBoardDateTimeContentState<T extends BoardDateTimeCommonResult>
       keyboardHeightRatio: keyboardHeightRatio,
       calendarAnimation: calendarAnimation,
       onCalendar: onCalendar,
-      onKeyboadClose: closeKeyboard,
+      onKeyboardClose: closeKeyboard,
       onClose: close,
       backgroundColor: widget.options.getBackgroundColor(context),
       foregroundColor: widget.options.getForegroundColor(context),

--- a/lib/src/options/board_item_option.dart
+++ b/lib/src/options/board_item_option.dart
@@ -365,8 +365,8 @@ class BoardPickerItemOption {
     // AMとPMの値に合わせて24時間表記の時間を置き換える
     final hour = itemMap[selectedIndex];
 
-    Map<int, AmpmCotrast> current;
-    Map<int, AmpmCotrast> next;
+    Map<int, AmpmContrast> current;
+    Map<int, AmpmContrast> next;
     if (ampm == AmPm.am) {
       current = DateTimeUtil.ampmContrastAmMap;
       next = DateTimeUtil.ampmContrastPmMap;

--- a/lib/src/ui/board_datetime_contents_state.dart
+++ b/lib/src/ui/board_datetime_contents_state.dart
@@ -31,7 +31,7 @@ abstract class BoardDateTimeContent<T extends BoardDateTimeCommonResult>
     this.keyboardHeightNotifier,
     this.onCreatedDateState,
     this.pickerFocusNode,
-    this.onKeyboadClose,
+    this.onKeyboardClose,
     this.onUpdateByClose,
     required this.headerWidget,
     required this.onTopActionBuilder,
@@ -61,7 +61,7 @@ abstract class BoardDateTimeContent<T extends BoardDateTimeCommonResult>
 
   final FocusNode? pickerFocusNode;
 
-  final void Function()? onKeyboadClose;
+  final void Function()? onKeyboardClose;
 
   /// Callback to update initial values if the date is never changed at close.
   /// Valid only for modal display.
@@ -229,9 +229,28 @@ abstract class BoardDatetimeContentState<T extends BoardDateTimeCommonResult,
 
   @override
   void dispose() {
+    _removeItemFocusListeners(itemOptions);
+    for (final x in itemOptions) {
+      x.focusNode.dispose();
+    }
+    if (isSelfKeyboardNotifier) {
+      keyboardHeightNotifier.dispose();
+    }
     openAnimationController.dispose();
     calendarAnimationController.dispose();
     super.dispose();
+  }
+
+  /// Removes the keyboard listeners registered in [setupOptions]
+  /// from the given options' focus nodes.
+  void _removeItemFocusListeners(List<BoardPickerItemOption> options) {
+    for (final x in options) {
+      if (x.type == DateType.year) {
+        x.focusNode.removeListener(yearKeyboardListener);
+      } else {
+        x.focusNode.removeListener(keyboardListener);
+      }
+    }
   }
 
   /// FocusNode (keyboard) listener
@@ -268,6 +287,8 @@ abstract class BoardDatetimeContentState<T extends BoardDateTimeCommonResult,
 
     final opts = widget.options.customOptions;
     final withSecond = widget.options.withSecond;
+
+    final oldItemOptions = itemOptions;
 
     List<BoardPickerItemOption> ymdOptions = [];
 
@@ -403,6 +424,19 @@ abstract class BoardDatetimeContentState<T extends BoardDateTimeCommonResult,
       }
     }
 
+    if (oldItemOptions.isNotEmpty) {
+      _removeItemFocusListeners(oldItemOptions);
+      // The ItemWidgets backed by oldItemOptions are still mounted at this
+      // point; they get replaced by the rebuild that this setState triggers.
+      // Defer disposal of their focus nodes until that rebuild has completed
+      // so the corresponding Focus widgets have already detached.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        for (final x in oldItemOptions) {
+          x.focusNode.dispose();
+        }
+      });
+    }
+
     pickerType = type;
   }
 
@@ -411,7 +445,7 @@ abstract class BoardDatetimeContentState<T extends BoardDateTimeCommonResult,
     for (final x in itemOptions) {
       if (x.focusNode.hasFocus) x.focusNode.unfocus();
     }
-    widget.onKeyboadClose?.call();
+    widget.onKeyboardClose?.call();
   }
 
   /// Handling of date changes made by the picker

--- a/lib/src/ui/parts/header.dart
+++ b/lib/src/ui/parts/header.dart
@@ -20,7 +20,7 @@ class BoardDateTimeHeader extends StatefulWidget {
     required this.onCalendar,
     required this.onChangeDate,
     required this.onChangTime,
-    required this.onKeyboadClose,
+    required this.onKeyboardClose,
     required this.onClose,
     required this.backgroundColor,
     required this.foregroundColor,
@@ -67,7 +67,7 @@ class BoardDateTimeHeader extends StatefulWidget {
   final void Function(DateTime) onChangTime;
 
   /// Keyboard close request
-  final void Function() onKeyboadClose;
+  final void Function() onKeyboardClose;
 
   /// Picker close request
   final void Function() onClose;
@@ -231,7 +231,7 @@ class BoardDateTimeHeaderState extends State<BoardDateTimeHeader> {
           //     opacity: 0.8 * (1 - widget.keyboardHeightRatio),
           //     child: IconButton(
           //       onPressed: () {
-          //         widget.onKeyboadClose();
+          //         widget.onKeyboardClose();
           //       },
           //       icon: const Icon(
           //         Icons.keyboard_hide_rounded,
@@ -409,7 +409,7 @@ class BoardDateTimeNoneButtonHeader extends StatefulWidget {
     required this.keyboardHeightRatio,
     required this.calendarAnimation,
     required this.onCalendar,
-    required this.onKeyboadClose,
+    required this.onKeyboardClose,
     required this.onClose,
     required this.modal,
     required this.pickerFocusNode,
@@ -437,7 +437,7 @@ class BoardDateTimeNoneButtonHeader extends StatefulWidget {
   final void Function() onCalendar;
 
   /// Keyboard close request
-  final void Function() onKeyboadClose;
+  final void Function() onKeyboardClose;
 
   /// Picker close request
   final void Function() onClose;
@@ -558,7 +558,7 @@ class _BoardDateTimeNoneButtonHeaderState
     //       icon: Icons.keyboard_hide_rounded,
     //       bgColor: widget.options.getForegroundColor(context),
     //       fgColor: widget.options.getTextColor(context),
-    //       onTap: widget.onKeyboadClose,
+    //       onTap: widget.onKeyboardClose,
     //       buttonSize: buttonSize,
     //     ),
     //   );

--- a/lib/src/ui/parts/header_multi.dart
+++ b/lib/src/ui/parts/header_multi.dart
@@ -20,7 +20,7 @@ class BoardDateTimeMultiHeader extends StatefulWidget {
     required this.keyboardHeightRatio,
     required this.calendarAnimation,
     required this.onCalendar,
-    required this.onKeyboadClose,
+    required this.onKeyboardClose,
     required this.onClose,
     required this.backgroundColor,
     required this.foregroundColor,
@@ -71,7 +71,7 @@ class BoardDateTimeMultiHeader extends StatefulWidget {
   final void Function() onCalendar;
 
   /// Keyboard close request
-  final void Function() onKeyboadClose;
+  final void Function() onKeyboardClose;
 
   /// Picker close request
   final void Function() onClose;

--- a/lib/src/ui/parts/item.dart
+++ b/lib/src/ui/parts/item.dart
@@ -65,8 +65,8 @@ class ItemWidgetState extends State<ItemWidget>
   bool _isAnimating = false;
 
   /// Timer for debouncing process
-  Timer? debouceTimer;
-  Timer? wheelDebouceTimer;
+  Timer? debounceTimer;
+  Timer? wheelDebounceTimer;
 
   /// Number of items to display in the list
   int get wheelCount => widget.wide || widget.embeddedOptions.fixed ? 7 : 5;
@@ -99,13 +99,13 @@ class ItemWidgetState extends State<ItemWidget>
   int getWheelIndex(int index) {
     if (useAmpmMode) {
       final hour = widget.option.itemMap[index];
-      final cotrast = DateTimeUtil.ampmContrastMap[hour]!;
+      final contrast = DateTimeUtil.ampmContrastMap[hour]!;
       final i = map.entries
           .firstWhereOrNull(
-            (x) => x.value == cotrast.hour,
+            (x) => x.value == contrast.hour,
           )
           ?.key;
-      return i ?? cotrast.index;
+      return i ?? contrast.index;
       // return DateTimeUtil.ampmContrastMap[hour]!.index;
     } else {
       return index;
@@ -115,7 +115,7 @@ class ItemWidgetState extends State<ItemWidget>
   /// Notify caller of changed index
   void callbackOnChange(int index) {
     if (useAmpmMode) {
-      Map<int, AmpmCotrast> contrastMap;
+      Map<int, AmpmContrast> contrastMap;
       if (widget.option.ampm! == AmPm.am) {
         contrastMap = DateTimeUtil.ampmContrastAmMap;
       } else {
@@ -178,8 +178,24 @@ class ItemWidgetState extends State<ItemWidget>
   }
 
   @override
+  void didUpdateWidget(ItemWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.foregroundColor != widget.foregroundColor) {
+      correctColor = ColorTween(
+        begin: widget.foregroundColor,
+        end: Colors.redAccent.withValues(alpha: 0.8),
+      ).animate(correctAnimationController);
+    }
+  }
+
+  @override
   void dispose() {
     widget.option.focusNode.removeListener(focusListener);
+    debounceTimer?.cancel();
+    wheelDebounceTimer?.cancel();
+    _updateTimer?.cancel();
+    correctAnimationController.dispose();
+    pickerFocusNode.dispose();
     scrollController.dispose();
     textController.dispose();
     super.dispose();
@@ -206,16 +222,16 @@ class ItemWidgetState extends State<ItemWidget>
       if (textController.text != text) {
         textController.text = text;
       }
-      debouceTimer?.cancel();
-      debouceTimer = null;
+      debounceTimer?.cancel();
+      debounceTimer = null;
     }
 
     // Debounce process to prevent inadvertent text updates when in focus
     if (widget.option.focusNode.hasFocus) {
-      debouceTimer?.cancel();
+      debounceTimer?.cancel();
       // Ignore empty characters as they do not need to be scrolled.
       if (textController.text != '') {
-        debouceTimer = Timer(const Duration(milliseconds: 300), setText);
+        debounceTimer = Timer(const Duration(milliseconds: 300), setText);
       }
     } else {
       setText();
@@ -515,16 +531,16 @@ class ItemWidgetState extends State<ItemWidget>
 
   /// Processing when text is changed
   void onChangeText(String text) {
-    wheelDebouceTimer?.cancel();
+    wheelDebounceTimer?.cancel();
 
     final index = _convertTextToIndex(text);
     if (index == null || index < 0) return;
     // Animated wheel movement
-    wheelDebouceTimer = Timer(
+    wheelDebounceTimer = Timer(
       const Duration(milliseconds: 200),
       () {
-        wheelDebouceTimer?.cancel();
-        wheelDebouceTimer = null;
+        wheelDebounceTimer?.cancel();
+        wheelDebounceTimer = null;
         toAnimateChange(index);
       },
     );
@@ -654,6 +670,7 @@ class AmpmItemWidgetState extends State<AmpmItemWidget> {
 
   @override
   void dispose() {
+    pickerFocusNode.dispose();
     scrollController.dispose();
     super.dispose();
   }

--- a/lib/src/ui/picker_calendar_widget.dart
+++ b/lib/src/ui/picker_calendar_widget.dart
@@ -28,7 +28,7 @@ class PickerCalendarArgs {
   final ValueNotifier<DateTime>? endDate;
   final void Function(DateTime start, DateTime end)? onMultiChange;
   final void Function(MultiCurrentDateType)? onChangeDateType;
-  final void Function() onKeyboadClose;
+  final void Function() onKeyboardClose;
 
   const PickerCalendarArgs({
     required this.dateState,
@@ -46,7 +46,7 @@ class PickerCalendarArgs {
     this.endDate,
     this.onMultiChange,
     this.onChangeDateType,
-    required this.onKeyboadClose,
+    required this.onKeyboardClose,
   });
 }
 
@@ -342,7 +342,7 @@ abstract class PickerCalendarState<T extends PickerCalendarWidget>
                 bgColor: args.options.getForegroundColor(context),
                 fgColor:
                     args.options.getTextColor(context)?.withValues(alpha: 0.6),
-                onTap: args.onKeyboadClose,
+                onTap: args.onKeyboardClose,
                 // buttonSize: buttonSize,
               ),
             ],

--- a/lib/src/utils/datetime_util.dart
+++ b/lib/src/utils/datetime_util.dart
@@ -82,39 +82,39 @@ class DateTimeUtil {
     return null;
   }
 
-  static Map<int, AmpmCotrast> ampmContrastMap = {
+  static Map<int, AmpmContrast> ampmContrastMap = {
     ...ampmContrastAmMap,
     ...ampmContrastPmMap,
   };
 
-  static Map<int, AmpmCotrast> ampmContrastAmMap = {
-    0: AmpmCotrast.am(12, 0),
-    for (var i = 1; i <= 11; i++) i: AmpmCotrast.am(i, i),
+  static Map<int, AmpmContrast> ampmContrastAmMap = {
+    0: AmpmContrast.am(12, 0),
+    for (var i = 1; i <= 11; i++) i: AmpmContrast.am(i, i),
   };
 
-  static Map<int, AmpmCotrast> ampmContrastPmMap = {
-    12: AmpmCotrast.pm(12, 0),
-    for (var i = 13; i <= 23; i++) i: AmpmCotrast.pm(i - 12, i - 12),
+  static Map<int, AmpmContrast> ampmContrastPmMap = {
+    12: AmpmContrast.pm(12, 0),
+    for (var i = 13; i <= 23; i++) i: AmpmContrast.pm(i - 12, i - 12),
   };
 }
 
-class AmpmCotrast {
+class AmpmContrast {
   final AmPm ampm;
   final int hour;
   final int index;
 
-  AmpmCotrast({required this.ampm, required this.hour, required this.index});
+  AmpmContrast({required this.ampm, required this.hour, required this.index});
 
-  factory AmpmCotrast.am(int hour, int index) {
-    return AmpmCotrast(
+  factory AmpmContrast.am(int hour, int index) {
+    return AmpmContrast(
       ampm: AmPm.am,
       hour: hour,
       index: index,
     );
   }
 
-  factory AmpmCotrast.pm(int hour, int index) {
-    return AmpmCotrast(
+  factory AmpmContrast.pm(int hour, int index) {
+    return AmpmContrast(
       ampm: AmPm.pm,
       hour: hour,
       index: index,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: board_datetime_picker
 description: >-
   Picker to select date and time for Flutter.  
   It is both a calendar and a picker, offering a variety of options as a package.  
-version: 2.8.5
+version: 2.8.6
 homepage: https://github.com/mytooyo/board_datetime_picker
 
 environment:
@@ -13,11 +13,11 @@ dependencies:
   flutter:
     sdk: flutter
   intl: any
-  collection: ^1.18.0
+  collection: ^1.19.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^6.0.0
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,11 +13,11 @@ dependencies:
   flutter:
     sdk: flutter
   intl: any
-  collection: ^1.19.1
+  collection: ^1.18.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^3.0.1
 
 flutter:


### PR DESCRIPTION
* Fixed the correction flash animation using a stale foreground color after the theme changed.
* Fixed memory leaks by disposing focus nodes, timers, animation controllers and notifiers that were left undisposed (`BoardDateTimeBuilder`, `BoardDateTimeInputField`, `BoardMultiDateTimeController`, picker item widgets).
* Fixed an issue where focus listeners on picker item options were not removed when the picker type changed, which could cause stale callbacks to fire.
* Replaced deprecated `SizeTransition.axisAlignment` with `alignment`.

This PR is mainly to fix this issue below:
**Before:**
https://github.com/user-attachments/assets/fe2cac39-3f96-4943-a8a0-9b0fd8e18a7d

**After**
https://github.com/user-attachments/assets/9d893a82-2752-48eb-8864-09954ff8e8ab


